### PR TITLE
fix pypi install error due to missing changelog

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include Changelog


### PR DESCRIPTION
setup.py expects it to be there, but it's not in the sdist.
