### PR TITLE
Fix process cmdline parsing for special case

### DIFF
--- a/cgutils/process.py
+++ b/cgutils/process.py
@@ -63,6 +63,11 @@ class Process(object):
             #args = [cmdline,]
             args = cmdline.split(' ')
             name = args[0]
+
+        if len(name) == 0:
+            name = os.path.basename(' '.join(args[0:2]))
+            return name
+
         if name[0] == '/':
             name = os.path.basename(name)
         name = name.rstrip(':')


### PR DESCRIPTION
Fixing command parsing for something like this
# cat /proc/1971/cmdline

'\x00-AOxRR\x003398.byobu\x00'

After args parsing, args equals ['', '-AOxRR', '3398.byobu'], which raise index out of range exception when referencing name[0] 
