### PR TITLE
Support new control files until 3.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ This command shows you tree structure of cgroups.
 
 #Supported Linux Version
 
-3.8.y
+3.18.y
 
 ##Supported subsystems
 

--- a/cgutils/cgroup.py
+++ b/cgutils/cgroup.py
@@ -382,6 +382,7 @@ class SubsystemMemory(Subsystem):
     }
     CONTROLS = {
         'force_empty': None,
+        'pressure_level': None,
     }
 
 
@@ -738,6 +739,7 @@ class EventListener:
         'memory.usage_in_bytes',
         'memory.oom_control',
         'memory.memsw.usage_in_bytes',
+        'memory.pressure_level',
     ]
 
     def __init__(self, cgroup, target_name):
@@ -770,8 +772,9 @@ class EventListener:
         if target_name in ['memory.usage_in_bytes', 'memory.memsw.usage_in_bytes']:
             threshold = arguments[0]
             line = "%d %d %d\0" % (self.event_fd, self.target_fd, long(threshold))
-        else:
-            line = "%d %d\0" % (self.event_fd, self.target_fd)
+        elif target_name in ['memory.pressure_level',]:
+            threshold = arguments[0]
+            line = "%d %d %s\0" % (self.event_fd, self.target_fd, threshold)
         os.write(self.ec_fd, line)
 
     def wait(self):

--- a/cgutils/cgroup.py
+++ b/cgutils/cgroup.py
@@ -321,11 +321,14 @@ class SubsystemCpuacct(Subsystem):
 class SubsystemCpuset(Subsystem):
     NAME = 'cpuset'
     STATS = {
+        # str object something like '0', '0-1', and '0-1,3,4'
+        'effective_cpus': str,
+        'effective_mems': str,
         'memory_pressure': long,
     }
     CONFIGS = {
         'cpu_exclusive': 0,
-        # str object something like '0', '0-1', and '0-1,3,4'
+        # same as 'effective_*' ones
         'cpus': host.CPUInfo().get_online(),
         'mem_exclusive': 0,
         'mem_hardwall': 0,

--- a/cgutils/cgroup.py
+++ b/cgutils/cgroup.py
@@ -785,6 +785,8 @@ class EventListener:
         elif target_name in ['memory.pressure_level']:
             threshold = arguments[0]
             line = "%d %d %s\0" % (self.event_fd, self.target_fd, threshold)
+        else:
+            line = "%d %d\0" % (self.event_fd, self.target_fd)
         os.write(self.ec_fd, line)
 
     def wait(self):

--- a/cgutils/cgroup.py
+++ b/cgutils/cgroup.py
@@ -782,7 +782,7 @@ class EventListener:
         if target_name in ['memory.usage_in_bytes', 'memory.memsw.usage_in_bytes']:
             threshold = arguments[0]
             line = "%d %d %d\0" % (self.event_fd, self.target_fd, long(threshold))
-        elif target_name in ['memory.pressure_level',]:
+        elif target_name in ['memory.pressure_level']:
             threshold = arguments[0]
             line = "%d %d %s\0" % (self.event_fd, self.target_fd, threshold)
         os.write(self.ec_fd, line)

--- a/cgutils/cgroup.py
+++ b/cgutils/cgroup.py
@@ -390,15 +390,23 @@ class SubsystemBlkio(Subsystem):
     NAME = 'blkio'
     STATS = {
         'io_merged': BlkioStat,
+        'io_merged_recursive': BlkioStat,
         'io_queued': BlkioStat,
+        'io_queued_recursive': BlkioStat,
         'io_service_bytes': BlkioStat,
+        'io_service_bytes_recursive': BlkioStat,
         'io_service_time': BlkioStat,
+        'io_service_time_recursive': BlkioStat,
         'io_serviced': BlkioStat,
+        'io_serviced_recursive': BlkioStat,
         'io_wait_time': BlkioStat,
+        'io_wait_time_recursive': BlkioStat,
         'sectors': SimpleStat,
+        'sectors_recursive': SimpleStat,
         'throttle.io_service_bytes': BlkioStat,
         'throttle.io_serviced': BlkioStat,
         'time': SimpleStat,
+        'time_recursive': SimpleStat,
         # Debugging files (Appeared only CONFIG_DEBUG_BLK_CGROUP=y)
         'avg_queue_size': BlkioStat,
         'dequeue': BlkioStat,
@@ -408,6 +416,8 @@ class SubsystemBlkio(Subsystem):
         'unaccounted_time': BlkioStat,
     }
     CONFIGS = {
+        'leaf_weight': 1000,
+        'leaf_weight_device': SimpleStat({}),
         'throttle.read_iops_device': SimpleStat({}),
         'throttle.write_iops_device': SimpleStat({}),
         'throttle.read_bps_device': SimpleStat({}),

--- a/cgutils/commands/event.py
+++ b/cgutils/commands/event.py
@@ -100,6 +100,15 @@ class Command(command.Command):
             if self.args.threshold:
                 self.parser.error('Too many arguments: ' + ' '.join(self.args))
 
+        elif target_name == 'memory.pressure_level':
+            SUPPORTED_TERMS = ['low', 'medium', 'critical']
+            if not self.args.threshold:
+                self.parser.error('Less arguments: ' + ' '.join(self.args))
+            if self.args.threshold not in SUPPORTED_TERMS:
+                self.parser.error('Use one of %p' % SUPPORTED_TERMS)
+
+            arguments.append(self.args.threshold)
+
         else:
             files = ', '.join(cgroup.EventListener.SUPPORTED_FILES)
             message = "Target file not supported: %s\n" % target_name


### PR DESCRIPTION
Linux is moving to 4.x. Before the event, we want to support all cgroup control files provided by 3.x!