### PR TITLE
Remove unnecessary `argparse` install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(name='cgroup-utils',
       url='https://github.com/peo3/cgroup-utils',
       license='GPLv2',
       classifiers=classifiers,
-      install_requires=['argparse'],
       tests_require=['nose', 'pep8'],
       test_suite='nose.collector',
       extras_require=dict(


### PR DESCRIPTION
The `argparse` module is part of stdlib since Python 3.2.  Since the package doesn't declare support for anything below 3.4, just remove the dependency entirely.